### PR TITLE
expose options to wintersmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 [Wintersmith](http://wintersmith.io) plugin for 
 [Markdown-it](https://github.com/markdown-it/markdown-it).
+
+Options:
+
+    "markdownit": {
+      "classPrefix": "",
+      "autoLanguage": false
+    }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -14,7 +14,9 @@ module.exports = ( env, callback ) ->
 
       md = markdown_it()
       .use require 'markdown-it-footnote'
-      .use require('./highlight'), classPrefix: ''
+      .use require('./highlight'), 
+        classPrefix: globalOptions?.classPrefix or "",
+        autoLanguage: globalOptions?.autoLanguage or false
       .use require('./resolve_links')(this, base)
 
       md.render @markdown


### PR DESCRIPTION
I figured it'd be helpful to expose the markdown-it options for use in `config.json`.
